### PR TITLE
README: link to build status page instead of badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![Build Status](https://travis-ci.org/UofABioinformaticsHub/ngsReports.svg?branch=master)](https://travis-ci.org/UofABioinformaticsHub/ngsReports.svg?branch=master)
+[![Build Status](https://travis-ci.org/UofABioinformaticsHub/ngsReports.svg?branch=master)](https://travis-ci.org/github/UofABioinformaticsHub/ngsReports/branches)
 [![Project Status: Active - The project has reached a stable, usable state and is being actively developed.](http://www.repostatus.org/badges/latest/active.svg)](http://www.repostatus.org/#active)
 
 


### PR DESCRIPTION
This makes clicking on the Travis build status badge take the user to the build status for all the branches, rather than just to another copy of the badge. The branches page is chosen over the project home build page since that just shows the last build status.

Please take a look.